### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ To compile and run this project, you will need:
 * requests
 * vk_api
 * anytree
-* fuzzywuzzy
-* python-Levenshtein
+* rapidfuzz
 * PySocks (optional, for proxy if needed)
 * Python3
 

--- a/core/text_processor/string_processor.py
+++ b/core/text_processor/string_processor.py
@@ -2,7 +2,7 @@
 
 import re
 
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 from core.logger import log_func, debug, DEBUG_LOG
 
@@ -19,7 +19,7 @@ def is_words_similar(string, model):
     :rtype: bool
     """
 
-    if fuzz.ratio(string, model) >= 75:
+    if fuzz.ratio(string, model, score_cutoff=75):
         return True
 
     return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 requests
 vk_api
 anytree
-fuzzywuzzy
-python-levenshtein
+rapidfuzz
 
 PySocks


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy